### PR TITLE
Add smoke test for stop-sauron startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stop Sauron
 
-:red_circle: `Last update 17 April 2026`
+:red_circle: `Last update 19 April 2026`
 
 To stop the all seeing eye of Sauron and make your MacBook operate as it should be.
 
@@ -22,14 +22,14 @@ Use at your own risk, but know I'm continuously using it on daily basis. I dying
 Make the script executable:
 
 ```zsh
-chmod +x ./stop-sauron.sh
+chmod +x ./stop-sauron ./stop-sauron.sh
 
 ```
 
 Run stop Sauron as sudo:
 
 ```zsh
-sudo ./stop-sauron.sh
+sudo ./stop-sauron
 
 ```
 
@@ -41,6 +41,14 @@ Select you demanded action out of the options
 * Option 4: Remove the config (Removing the original configuration files, create on the first run)
 * Option 5: Create lifesaver (Creating a backupfile of the configuration files)
 * Option 6: Exit (without any actions)
+
+## Smoke test
+
+Run the repository smoke test with:
+
+```zsh
+bash ./tests/smoke_test.sh
+```
 
 
 ## Compatibility

--- a/configuration.sh
+++ b/configuration.sh
@@ -2,45 +2,59 @@
 #------------------------#
 # Version
 #------------------------#
-VERSION="1.1.6.19.04.2026"
+VERSION="1.1.7.19.04.2026"
+LAUNCHCTL_BIN="${STOP_SAURON_LAUNCHCTL_BIN:-/bin/launchctl}"
 
 
 #------------------------#
 # Users
 #------------------------#
-LOCAL_USER=$USER
-SUDO_USER=$SUDO_USER
+LOCAL_USER="${LOCAL_USER:-$USER}"
+SUDO_USER="${SUDO_USER:-$LOCAL_USER}"
+
+#------------------------#
+# State
+#------------------------#
+STATE_DIR="${STOP_SAURON_STATE_DIR:-.}"
 
 #------------------------#
 # Logfiles
 #------------------------#
 USER_LOG_FOLDER=".stop-sauron"
-USER_LOG_FILE="debug.log"
-PLIST_DEAMON_CONF="plist-deamon.backup.conf"
-PLIST_DEAMON_BACKUP="plist-deamon.backup.conf.bak"
-PLIST_AGENT_CONF="plist-agent.backup.conf"
-PLIST_AGENT_BACKUP="plist-agent.backup.conf.bak"
+USER_LOG_FILE="${STATE_DIR}/debug.log"
+PLIST_DEAMON_CONF="${STATE_DIR}/plist-deamon.backup.conf"
+PLIST_DEAMON_BACKUP="${STATE_DIR}/plist-deamon.backup.conf.bak"
+PLIST_AGENT_CONF="${STATE_DIR}/plist-agent.backup.conf"
+PLIST_AGENT_BACKUP="${STATE_DIR}/plist-agent.backup.conf.bak"
 
 #------------------------#
 # Plist paths
 #------------------------#
-plistPathArray=(
-#    "~/Library/LaunchAgents"         # Per-user agents provided by the user.
-    "/Library/LaunchAgents"          # Per-user agents provided by the administrator.
-    "/Library/LaunchDaemons"         # System wide daemons provided by the administrator.
-    "/System/Library/LaunchAgents"   # Mac OS X Per-user agents.
-    "/System/Library/LaunchDaemons"  # Mac OS X System wide daemons.
-)
+if [[ -n "${STOP_SAURON_PLIST_PATHS:-}" ]]; then
+    IFS=':' read -r -a plistPathArray <<< "$STOP_SAURON_PLIST_PATHS"
+else
+    plistPathArray=(
+    #    "~/Library/LaunchAgents"         # Per-user agents provided by the user.
+        "/Library/LaunchAgents"          # Per-user agents provided by the administrator.
+        "/Library/LaunchDaemons"         # System wide daemons provided by the administrator.
+        "/System/Library/LaunchAgents"   # Mac OS X Per-user agents.
+        "/System/Library/LaunchDaemons"  # Mac OS X System wide daemons.
+    )
+fi
 
 #------------------------#
 # Software packages
 #------------------------#
-applicationsArray=(
-    "com.airwatch"
-    "com.fireeye"
-    "com.mcafee"
-    "com.zscaler"
-    "com.cylance"
-    "com.crowdstrike"
-    "com.rapid7"
-)
+if [[ -n "${STOP_SAURON_APPLICATIONS:-}" ]]; then
+    IFS=':' read -r -a applicationsArray <<< "$STOP_SAURON_APPLICATIONS"
+else
+    applicationsArray=(
+        "com.airwatch"
+        "com.fireeye"
+        "com.mcafee"
+        "com.zscaler"
+        "com.cylance"
+        "com.crowdstrike"
+        "com.rapid7"
+    )
+fi

--- a/init.sh
+++ b/init.sh
@@ -107,13 +107,13 @@ findProcesses() {
         if [[ "$basename" == "LaunchAgents" ]]; then
             # Check the USER processes from a root viewpoint
             DEAMON_TYPE="Agent"
-            var1=$(su - "$SUDO_USER" -c "ps -A | /bin/launchctl list | grep -m1 -- \"$filename\"")
+            var1=$(su - "$SUDO_USER" -c "ps -A | \"$LAUNCHCTL_BIN\" list | grep -m1 -- \"$filename\"")
             PROCESS=$(echo "$var1" | awk '{print $1}')
             
         else
             # Get Deamon PID
             DEAMON_TYPE="Deamon"
-            PROCESS="$(ps -Ac | /bin/launchctl list | grep -m1 "$filename" | awk '{print $1}')"
+            PROCESS="$(ps -Ac | "$LAUNCHCTL_BIN" list | grep -m1 "$filename" | awk '{print $1}')"
         fi
                 
         # Check if process is a number

--- a/stop-sauron
+++ b/stop-sauron
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$SCRIPT_DIR/stop-sauron.sh" "$@"

--- a/stop-sauron.sh
+++ b/stop-sauron.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-[[ $EUID == 0 ]] || {
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_EUID="${STOP_SAURON_TEST_EUID_OVERRIDE:-$EUID}"
+
+[[ $ROOT_EUID == 0 ]] || {
     echo "Must be run as root."
     exit
 }
@@ -8,9 +11,9 @@
 #------------------------#
 # imports
 #------------------------#
-. configuration.sh
-. shared.sh
-. init.sh
+. "$SCRIPT_DIR/configuration.sh"
+. "$SCRIPT_DIR/shared.sh"
+. "$SCRIPT_DIR/init.sh"
 
 
 #------------------------#
@@ -198,7 +201,7 @@ theExecution() {
             filename="${filename%.*}"
 
             # Get agent PID
-            var1=$(su - "$SUDO_USER" -c "ps -A | /bin/launchctl list | grep -m1 -- \"$filename\"")
+            var1=$(su - "$SUDO_USER" -c "ps -A | \"$LAUNCHCTL_BIN\" list | grep -m1 -- \"$filename\"")
             PROCESS=$(echo "$var1" | awk '{print $1}')
                 
             # Check if process is a number
@@ -207,7 +210,7 @@ theExecution() {
             else
                 # take action
                 writeLog "[exec] --> $ACTION --> $d"
-                su - "$SUDO_USER" -c "/bin/launchctl \"$LOADER\" -w \"$d\""
+                su - "$SUDO_USER" -c "\"$LAUNCHCTL_BIN\" \"$LOADER\" -w \"$d\""
             fi
         done
         writeLog "[exec] - Resolved --> $ACTION Agents"
@@ -219,14 +222,14 @@ theExecution() {
         writeLog "[exec] - Start --> $ACTION Deamons"
         for g in "${arrayDeamonsfromConfig[@]}"; do
             writeLog "[exec] --> $ACTION --> $g"
-            /bin/launchctl "$LOADER" -w "$g"
+            "$LAUNCHCTL_BIN" "$LOADER" -w "$g"
         done
         writeLog "[exec] - Resolved --> $ACTION Deamons"
 
         writeLog "[exec] - Start --> $ACTION Agents"
         for h in "${arrayAgentsfromConfig[@]}"; do
             writeLog "[exec] --> $ACTION --> $h"
-            su - "$SUDO_USER" -c "/bin/launchctl \"$LOADER\" -w \"$h\""
+            su - "$SUDO_USER" -c "\"$LAUNCHCTL_BIN\" \"$LOADER\" -w \"$h\""
         done
         writeLog "[exec] - Resolved --> $ACTION Agents"
 

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/stop-sauron-smoke.XXXXXX")"
+STATE_DIR="$TEST_ROOT/state"
+MOCK_BIN_DIR="$TEST_ROOT/mock-bin"
+PLIST_ROOT="$TEST_ROOT/plists"
+AGENT_DIR="$PLIST_ROOT/LaunchAgents"
+DAEMON_DIR="$PLIST_ROOT/LaunchDaemons"
+LIST_FILE="$TEST_ROOT/launchctl-list.txt"
+ACTIONS_LOG="$TEST_ROOT/launchctl-actions.log"
+
+cleanup() {
+    rm -rf "$TEST_ROOT"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$STATE_DIR" "$MOCK_BIN_DIR" "$AGENT_DIR" "$DAEMON_DIR"
+touch "$ACTIONS_LOG"
+
+cat <<'EOF' > "$MOCK_BIN_DIR/launchctl"
+#!/bin/bash
+set -euo pipefail
+
+command="${1:-}"
+shift || true
+
+case "$command" in
+    list)
+        if [[ -f "${STOP_SAURON_MOCK_LAUNCHCTL_LIST_FILE:-}" ]]; then
+            cat "${STOP_SAURON_MOCK_LAUNCHCTL_LIST_FILE}"
+        fi
+        ;;
+    load|unload)
+        printf '%s %s\n' "$command" "$*" >> "${STOP_SAURON_MOCK_LAUNCHCTL_ACTIONS_LOG}"
+        ;;
+    *)
+        printf 'unexpected launchctl command: %s\n' "$command" >&2
+        exit 1
+        ;;
+esac
+EOF
+
+cat <<'EOF' > "$MOCK_BIN_DIR/su"
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-" ]]; then
+    shift
+fi
+
+if [[ $# -lt 2 || "${2:-}" != "-c" ]]; then
+    printf 'unexpected su invocation\n' >&2
+    exit 1
+fi
+
+shift
+shift
+command="${1:-}"
+bash -c "$command"
+EOF
+
+cat <<'EOF' > "$MOCK_BIN_DIR/ps"
+#!/bin/bash
+exit 0
+EOF
+
+cat <<'EOF' > "$MOCK_BIN_DIR/sw_vers"
+#!/bin/bash
+set -euo pipefail
+
+case "${1:-}" in
+    -productName)
+        echo "macOS"
+        ;;
+    -productVersion)
+        echo "15.5"
+        ;;
+    -buildVersion)
+        echo "24F79"
+        ;;
+    *)
+        echo "ProductName: macOS"
+        echo "ProductVersion: 15.5"
+        echo "BuildVersion: 24F79"
+        ;;
+esac
+EOF
+
+cat <<'EOF' > "$MOCK_BIN_DIR/sysctl"
+#!/bin/bash
+echo "hw.model: MacBookPro18,1"
+EOF
+
+cat <<'EOF' > "$MOCK_BIN_DIR/ioreg"
+#!/bin/bash
+echo '"IOPlatformSerialNumber" = "SMOKETEST123"'
+EOF
+
+chmod +x "$MOCK_BIN_DIR/launchctl" "$MOCK_BIN_DIR/su" "$MOCK_BIN_DIR/ps" "$MOCK_BIN_DIR/sw_vers" "$MOCK_BIN_DIR/sysctl" "$MOCK_BIN_DIR/ioreg"
+
+touch "$AGENT_DIR/com.test.agent.plist" "$DAEMON_DIR/com.test.daemon.plist"
+cat <<EOF > "$LIST_FILE"
+123 0 com.test.agent
+456 0 com.test.daemon
+EOF
+
+run_app() {
+    local choice="$1"
+
+    printf '%s\n' "$choice" | env \
+        PATH="$MOCK_BIN_DIR:$PATH" \
+        STOP_SAURON_TEST_EUID_OVERRIDE=0 \
+        STOP_SAURON_LAUNCHCTL_BIN="$MOCK_BIN_DIR/launchctl" \
+        STOP_SAURON_STATE_DIR="$STATE_DIR" \
+        STOP_SAURON_PLIST_PATHS="$AGENT_DIR:$DAEMON_DIR" \
+        STOP_SAURON_APPLICATIONS="com.test.agent:com.test.daemon" \
+        STOP_SAURON_MOCK_LAUNCHCTL_LIST_FILE="$LIST_FILE" \
+        STOP_SAURON_MOCK_LAUNCHCTL_ACTIONS_LOG="$ACTIONS_LOG" \
+        SUDO_USER="smoketest" \
+        "$REPO_DIR/stop-sauron"
+}
+
+assert_file_contains() {
+    local file="$1"
+    local pattern="$2"
+
+    if ! grep -Fq -- "$pattern" "$file"; then
+        printf 'expected %s to contain %s\n' "$file" "$pattern" >&2
+        exit 1
+    fi
+}
+
+assert_exists() {
+    local path="$1"
+
+    if [[ ! -f "$path" ]]; then
+        printf 'expected file to exist: %s\n' "$path" >&2
+        exit 1
+    fi
+}
+
+run_app 6 >/dev/null
+assert_exists "$STATE_DIR/plist-agent.backup.conf"
+assert_exists "$STATE_DIR/plist-deamon.backup.conf"
+assert_file_contains "$STATE_DIR/plist-agent.backup.conf" "$AGENT_DIR/com.test.agent.plist"
+assert_file_contains "$STATE_DIR/plist-deamon.backup.conf" "$DAEMON_DIR/com.test.daemon.plist"
+
+run_app 5 >/dev/null
+assert_exists "$STATE_DIR/plist-agent.backup.conf.bak"
+assert_exists "$STATE_DIR/plist-deamon.backup.conf.bak"
+
+run_app 1 >/dev/null
+assert_file_contains "$ACTIONS_LOG" "unload -w $DAEMON_DIR/com.test.daemon.plist"
+assert_file_contains "$ACTIONS_LOG" "unload -w $AGENT_DIR/com.test.agent.plist"
+
+echo "Smoke test passed."


### PR DESCRIPTION
## Summary
- add a repo-local `stop-sauron` entrypoint so the app can be started with `sudo ./stop-sauron`
- make the launcher configurable enough to run safely under a mocked smoke-test environment
- add `tests/smoke_test.sh` to verify startup, config generation, backup creation, and unload execution
- document the new entrypoint and smoke-test command in the README

## Testing
- `bash ./tests/smoke_test.sh`