### PR TITLE
Detect supported software from install.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Run the repository smoke test with:
 bash ./tests/smoke_test.sh
 ```
 
+On first discovery, Stop Sauron now also checks `/private/var/log/install.log` for supported software names and uses that to narrow the plist search before falling back to the full supported package list.
+
 
 ## Compatibility
 

--- a/configuration.sh
+++ b/configuration.sh
@@ -4,6 +4,7 @@
 #------------------------#
 VERSION="1.1.7.19.04.2026"
 LAUNCHCTL_BIN="${STOP_SAURON_LAUNCHCTL_BIN:-/bin/launchctl}"
+INSTALL_LOG_FILE="${STOP_SAURON_INSTALL_LOG:-/private/var/log/install.log}"
 
 
 #------------------------#

--- a/init.sh
+++ b/init.sh
@@ -25,6 +25,62 @@ prepare() {
     writeLog "[Prepare] - Stop"
 }
 
+applicationMatchesInstallLog() {
+    applicationIdentifier="$1"
+    installLogLine="$2"
+
+    case "$applicationIdentifier" in
+        "com.airwatch")
+            [[ "$installLogLine" == *"Workspace ONE Intelligent Hub"* ]] || [[ "$installLogLine" == *"AirWatch"* ]]
+            ;;
+        "com.fireeye")
+            [[ "$installLogLine" == *"FireEye Agent"* ]]
+            ;;
+        "com.mcafee")
+            [[ "$installLogLine" == *"McAfee"* ]] || [[ "$installLogLine" == *"MFEdx-ma"* ]]
+            ;;
+        "com.zscaler")
+            [[ "$installLogLine" == *"Zscaler"* ]]
+            ;;
+        "com.cylance")
+            [[ "$installLogLine" == *"Cylance"* ]]
+            ;;
+        "com.crowdstrike")
+            [[ "$installLogLine" == *"CrowdStrike"* ]] || [[ "$installLogLine" == *"Falcon"* ]]
+            ;;
+        "com.rapid7")
+            [[ "$installLogLine" == *"Rapid7"* ]] || [[ "$installLogLine" == *"Rabit7"* ]] || [[ "$installLogLine" == *"Insight Agent"* ]]
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+resolveApplicationsToScan() {
+    detectedApplicationsArray=()
+
+    if [[ ! -f "$INSTALL_LOG_FILE" ]]; then
+        writeLog "[Install Log] - Not found --> $INSTALL_LOG_FILE"
+        return
+    fi
+
+    writeLog "[Install Log] - Start --> Detect supported software from $INSTALL_LOG_FILE"
+
+    while IFS= read -r installLogLine; do
+        for applicationIdentifier in "${applicationsArray[@]}"; do
+            if applicationMatchesInstallLog "$applicationIdentifier" "$installLogLine"; then
+                if ! arrayContainsValue "$applicationIdentifier" "${detectedApplicationsArray[@]}"; then
+                    detectedApplicationsArray+=("$applicationIdentifier")
+                    writeLog "[Install Log] - Detected --> $applicationIdentifier"
+                fi
+            fi
+        done
+    done < <(grep 'Installed' "$INSTALL_LOG_FILE")
+
+    writeLog "[Install Log] - Resolved --> detected supported packages: ${#detectedApplicationsArray[@]}"
+}
+
 createLogFile() {
 
     #logLocation="${HOME}/"
@@ -142,8 +198,18 @@ findFiles() {
     writeLog "[Files] - Start --> Find Plists"
 
     plistArray=()
+    applicationsToScan=("${applicationsArray[@]}")
 
-    for t in "${applicationsArray[@]}"; do
+    resolveApplicationsToScan;
+
+    if [[ "${#detectedApplicationsArray[@]}" -gt 0 ]]; then
+        applicationsToScan=("${detectedApplicationsArray[@]}")
+        writeLog "[Files] - Using detected applications from install.log"
+    else
+        writeLog "[Files] - Using default supported applications list"
+    fi
+
+    for t in "${applicationsToScan[@]}"; do
         
         writeLog "[Application] - Locate --> $t"
        

--- a/shared.sh
+++ b/shared.sh
@@ -37,6 +37,19 @@ isFolder() {
     [  -d "$FOLDER" ]
 }
 
+arrayContainsValue() {
+    lookupValue="$1"
+    shift
+
+    for currentValue in "$@"; do
+        if [[ "$currentValue" == "$lookupValue" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 
 #------------------------#
 # Greeting message

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -12,6 +12,7 @@ AGENT_DIR="$PLIST_ROOT/LaunchAgents"
 DAEMON_DIR="$PLIST_ROOT/LaunchDaemons"
 LIST_FILE="$TEST_ROOT/launchctl-list.txt"
 ACTIONS_LOG="$TEST_ROOT/launchctl-actions.log"
+INSTALL_LOG="$TEST_ROOT/install.log"
 
 cleanup() {
     rm -rf "$TEST_ROOT"
@@ -109,6 +110,11 @@ cat <<EOF > "$LIST_FILE"
 456 0 com.test.daemon
 EOF
 
+cat <<EOF > "$INSTALL_LOG"
+2020-12-22 03:01:13-08 macbook-pro installd[465]: Installed "VMware Workspace ONE Intelligent Hub" ()
+2020-12-22 12:48:11+01 MacBook-Pro installd[663]: Installed "FireEye Agent" (33.22.6)
+EOF
+
 run_app() {
     local choice="$1"
 
@@ -116,6 +122,7 @@ run_app() {
         PATH="$MOCK_BIN_DIR:$PATH" \
         STOP_SAURON_TEST_EUID_OVERRIDE=0 \
         STOP_SAURON_LAUNCHCTL_BIN="$MOCK_BIN_DIR/launchctl" \
+        STOP_SAURON_INSTALL_LOG="$INSTALL_LOG" \
         STOP_SAURON_STATE_DIR="$STATE_DIR" \
         STOP_SAURON_PLIST_PATHS="$AGENT_DIR:$DAEMON_DIR" \
         STOP_SAURON_APPLICATIONS="com.test.agent:com.test.daemon" \
@@ -157,5 +164,37 @@ assert_exists "$STATE_DIR/plist-deamon.backup.conf.bak"
 run_app 1 >/dev/null
 assert_file_contains "$ACTIONS_LOG" "unload -w $DAEMON_DIR/com.test.daemon.plist"
 assert_file_contains "$ACTIONS_LOG" "unload -w $AGENT_DIR/com.test.agent.plist"
+
+DETECTION_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/stop-sauron-detect.XXXXXX")"
+DETECTION_STATE_DIR="$DETECTION_ROOT/state"
+DETECTION_PLIST_ROOT="$DETECTION_ROOT/plists"
+DETECTION_AGENT_DIR="$DETECTION_PLIST_ROOT/LaunchAgents"
+DETECTION_DAEMON_DIR="$DETECTION_PLIST_ROOT/LaunchDaemons"
+DETECTION_LIST_FILE="$DETECTION_ROOT/launchctl-list.txt"
+mkdir -p "$DETECTION_STATE_DIR" "$DETECTION_AGENT_DIR" "$DETECTION_DAEMON_DIR"
+touch "$DETECTION_AGENT_DIR/com.airwatch.helper.plist" "$DETECTION_DAEMON_DIR/com.fireeye.daemon.plist" "$DETECTION_DAEMON_DIR/com.mcafee.unexpected.plist"
+cat <<EOF > "$DETECTION_LIST_FILE"
+123 0 com.airwatch.helper
+456 0 com.fireeye.daemon
+EOF
+
+printf '6\n' | env \
+    PATH="$MOCK_BIN_DIR:$PATH" \
+    STOP_SAURON_TEST_EUID_OVERRIDE=0 \
+    STOP_SAURON_LAUNCHCTL_BIN="$MOCK_BIN_DIR/launchctl" \
+    STOP_SAURON_INSTALL_LOG="$INSTALL_LOG" \
+    STOP_SAURON_MOCK_LAUNCHCTL_LIST_FILE="$DETECTION_LIST_FILE" \
+    STOP_SAURON_STATE_DIR="$DETECTION_STATE_DIR" \
+    STOP_SAURON_PLIST_PATHS="$DETECTION_AGENT_DIR:$DETECTION_DAEMON_DIR" \
+    SUDO_USER="smoketest" \
+    "$REPO_DIR/stop-sauron" >/dev/null
+
+assert_file_contains "$DETECTION_STATE_DIR/plist-agent.backup.conf" "$DETECTION_AGENT_DIR/com.airwatch.helper.plist"
+assert_file_contains "$DETECTION_STATE_DIR/plist-deamon.backup.conf" "$DETECTION_DAEMON_DIR/com.fireeye.daemon.plist"
+if grep -Fq -- "com.mcafee.unexpected.plist" "$DETECTION_STATE_DIR/plist-deamon.backup.conf"; then
+    printf 'install.log detection should skip unsupported software absent from the log\n' >&2
+    exit 1
+fi
+rm -rf "$DETECTION_ROOT"
 
 echo "Smoke test passed."


### PR DESCRIPTION
Closes #12

## Summary
- detect supported software from `/private/var/log/install.log` during first-run discovery
- narrow plist scanning to software found in the install log, with a fallback to the full supported package list when nothing is detected
- add smoke-test coverage for the install-log detection path and document the behavior in the README

## Testing
- `bash ./tests/smoke_test.sh`